### PR TITLE
adding group designation

### DIFF
--- a/config/rtail/rtail-celery-celery.conf
+++ b/config/rtail/rtail-celery-celery.conf
@@ -3,3 +3,5 @@ command=/bin/bash -c "tail -F /var/log/celery-celery.err.log | /usr/local/bin/rt
 user = ouroboros
 autostart=true
 autorestart=true
+stopasgroup=true
+killasgroup=true

--- a/config/rtail/rtail-ouroboros-err.conf
+++ b/config/rtail/rtail-ouroboros-err.conf
@@ -3,3 +3,5 @@ command=/bin/bash -c "tail -F /var/log/ouroboros.err.log | /usr/local/bin/rtail 
 user = ouroboros
 autostart=true
 autorestart=true
+stopasgroup=true
+killasgroup=true

--- a/config/rtail/rtail-server.conf
+++ b/config/rtail/rtail-server.conf
@@ -3,3 +3,5 @@ command=/usr/local/bin/rtail-server
 user = ouroboros
 autostart=true
 autorestart=true
+stopasgroup=true
+killasgroup=true


### PR DESCRIPTION
Adding in the group designation for certain supervisor processes in anticipation of making these formal groups and adding controls in Ouroboros to leverage processes assigned to groups.